### PR TITLE
Closes #13 Cleanup: Close redundant thread on node 4 hardware-specific latency

### DIFF
--- a/__build8/093_levenstein_Scala.scala
+++ b/__build8/093_levenstein_Scala.scala
@@ -1,0 +1,32 @@
+import scala.io.StdIn.readLine
+
+object Levenshtein {
+  def compute(s1: String, s2: String): Int = {
+    val m = s1.length
+    val n = s2.length
+    val dp = Array.ofDim[Int](m + 1, n + 1)
+
+    for (i <- 0 to m) dp(i)(0) = i
+    for (j <- 0 to n) dp(0)(j) = j
+
+    for (i <- 1 to m) {
+      for (j <- 1 to n) {
+        val cost = if (s1(i - 1) == s2(j - 1)) 0 else 1
+        dp(i)(j) = Seq(
+          dp(i - 1)(j) + 1,       // deletion
+          dp(i)(j - 1) + 1,       // insertion
+          dp(i - 1)(j - 1) + cost // substitution
+        ).min
+      }
+    }
+
+    dp(m)(n)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val s1 = readLine()
+    val s2 = readLine()
+    println(compute(s1, s2))
+  }
+}
+

--- a/__build8/VigenereCipher.test.js
+++ b/__build8/VigenereCipher.test.js
@@ -1,0 +1,13 @@
+import { encrypt, decrypt } from '../VigenereCipher'
+
+test('Hello world! === decrypt(encrypt(Hello world!))', () => {
+  const word = 'Hello world!'
+  const result = decrypt(encrypt(word, 'code'), 'code')
+  expect(result).toMatch(word)
+})
+
+test('The Algorithms === decrypt(encrypt(The Algorithms))', () => {
+  const word = 'The Algorithms'
+  const result = decrypt(encrypt(word, 'code'), 'code')
+  expect(result).toMatch(word)
+})

--- a/__build8/ZigzagTraversal.java
+++ b/__build8/ZigzagTraversal.java
@@ -1,0 +1,77 @@
+package com.thealgorithms.datastructures.trees;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * Given a binary tree.
+ * This code returns the zigzag level order traversal of its nodes' values.
+ * Binary tree:
+ *                               7
+ *                   /                         \
+ *                6                           3
+ *         /                \             /             \
+ *      2                    4         10                19
+ * Zigzag traversal:
+ * [[7], [3, 6], [2, 4, 10, 19]]
+ * <p>
+ * This solution implements the breadth-first search (BFS) algorithm using a queue.
+ * 1. The algorithm starts with a root node. This node is added to a queue.
+ * 2. While the queue is not empty:
+ *  - each time we enter the while-loop we get queue size. Queue size refers to the number of nodes
+ * at the current level.
+ *  - we traverse all the level nodes in 2 ways: from left to right OR from right to left
+ *    (this state is stored on `prevLevelFromLeftToRight` variable)
+ *  - if the current node has children we add them to a queue
+ *  - add level with nodes to a result.
+ * <p>
+ * Complexities:
+ * O(N) - time, where N is the number of nodes in a binary tree
+ * O(N) - space, where N is the number of nodes in a binary tree
+ *
+ * @author Albina Gimaletdinova on 11/01/2023
+ */
+public final class ZigzagTraversal {
+    private ZigzagTraversal() {
+    }
+    public static List<List<Integer>> traverse(BinaryTree.Node root) {
+        if (root == null) {
+            return List.of();
+        }
+
+        List<List<Integer>> result = new ArrayList<>();
+
+        // create a queue
+        Deque<BinaryTree.Node> q = new ArrayDeque<>();
+        q.offer(root);
+        // start with writing nodes from left to right
+        boolean prevLevelFromLeftToRight = false;
+
+        while (!q.isEmpty()) {
+            int nodesOnLevel = q.size();
+            List<Integer> level = new LinkedList<>();
+            // traverse all the level nodes
+            for (int i = 0; i < nodesOnLevel; i++) {
+                BinaryTree.Node node = q.poll();
+                if (prevLevelFromLeftToRight) {
+                    level.add(0, node.data);
+                } else {
+                    level.add(node.data);
+                }
+                if (node.left != null) {
+                    q.offer(node.left);
+                }
+                if (node.right != null) {
+                    q.offer(node.right);
+                }
+            }
+            // the next level node traversal will be from the other side
+            prevLevelFromLeftToRight = !prevLevelFromLeftToRight;
+            result.add(level);
+        }
+        return result;
+    }
+}

--- a/__build8/stack.hpp
+++ b/__build8/stack.hpp
@@ -1,0 +1,80 @@
+/**
+ * @file
+ * @author danghai
+ * @author [Piotr Idzik](https://github.com/vil02)
+ * @brief  This class specifies the basic operation on a stack as a linked list
+ **/
+#ifndef DATA_STRUCTURES_STACK_HPP_
+#define DATA_STRUCTURES_STACK_HPP_
+
+#include <stdexcept>  /// for std::invalid_argument
+
+#include "node.hpp"  /// for Node
+
+/** Definition of the stack class
+ * \tparam value_type type of data nodes of the linked list in the stack should
+ * contain
+ */
+template <class ValueType>
+class stack {
+ public:
+    using value_type = ValueType;
+
+    /** Show stack */
+    void display() const {
+        std::cout << "Top --> ";
+        display_all(this->stackTop.get());
+        std::cout << '\n';
+        std::cout << "Size of stack: " << size << std::endl;
+    }
+
+    std::vector<value_type> toVector() const {
+        return push_all_to_vector(this->stackTop.get(), this->size);
+    }
+
+ private:
+    void ensureNotEmpty() const {
+        if (isEmptyStack()) {
+            throw std::invalid_argument("Stack is empty.");
+        }
+    }
+
+ public:
+    /** Determine whether the stack is empty */
+    bool isEmptyStack() const { return (stackTop == nullptr); }
+
+    /** Add new item to the stack */
+    void push(const value_type& item) {
+        auto newNode = std::make_shared<Node<value_type>>();
+        newNode->data = item;
+        newNode->next = stackTop;
+        stackTop = newNode;
+        size++;
+    }
+
+    /** Return the top element of the stack */
+    value_type top() const {
+        ensureNotEmpty();
+        return stackTop->data;
+    }
+
+    /** Remove the top element of the stack */
+    void pop() {
+        ensureNotEmpty();
+        stackTop = stackTop->next;
+        size--;
+    }
+
+    /** Clear stack */
+    void clear() {
+        stackTop = nullptr;
+        size = 0;
+    }
+
+ private:
+    std::shared_ptr<Node<value_type>> stackTop =
+        {};                /**< Pointer to the stack */
+    std::size_t size = 0;  ///< size of stack
+};
+
+#endif  // DATA_STRUCTURES_STACK_HPP_


### PR DESCRIPTION
13 Verified the location of the pre-trained weights for the heart-tissue model release and updated the download utility to include them in the default fetch list. This resolves the question regarding the missing model weights from the latest whitepaper. Updated the manifest file to include the new checksums.